### PR TITLE
onFinish prop & missing default halfWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are a few properties that define the behaviour of the component, here they
 |------|------|---------|------|
 | `loopForever` | `bool` | `false` | Indicates if the component should go back to the first page when reaching last page, and go back to last page after reaching first page. |
 | `orientation` | `string` | `vertical` | Orientation of swipes. `vertical` or `horizontal` for respectively up/down swipes and left/right swipes. |
+| `onFinish(orientation)` | `function` | `null` | Function called after the swipe is finished. Only usable if `loopForever` is `false`. |
 
 ## Contribute
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ class FlipPage extends React.Component {
       angle: 0,
       page: 0,
       halfHeight: 0,
+      halfWidth: 0,
       shouldGoNext: false,
       shouldGoPrevious: false,
       direction: '',
@@ -158,8 +159,10 @@ class FlipPage extends React.Component {
     const secondHalf = this.secondHalves[page];
 
     const finish = () => {
+      const { onFinish } = this.props;
+      const { direction } = this.state;
       this.setState({ direction: '' });
-
+      
       if (shouldGoNext) {
         this.setState({
           angle: 0,
@@ -176,6 +179,10 @@ class FlipPage extends React.Component {
           firstHalf.setNativeProps({ transform: [] });
           secondHalf.setNativeProps({ transform: [] });
         });
+      } else {
+        if (typeof onFinish === 'function') {
+          onFinish(direction);
+        }
       }
     };
 
@@ -366,11 +373,13 @@ class FlipPage extends React.Component {
 FlipPage.propTypes = {
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   loopForever: PropTypes.bool,
+  onFinish: PropTypes.func,
 };
 
 FlipPage.defaultProps = {
   orientation: 'vertical',
   loopForever: false,
+  onFinish: null,
 };
 
 class FlipPagePage extends React.PureComponent {


### PR DESCRIPTION
Missing deafult halfWidth in the state with horizontal orientation caused a crash of the app (width was NaN for RTCView). 

Function onFinish is called after the animation finish. 