### PR TITLE
Rendering of bunch of items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ class FlipPage extends React.Component {
       const { onFinish } = this.props;
       const { direction } = this.state;
       this.setState({ direction: '' });
-      
+
       if (shouldGoNext) {
         this.setState({
           angle: 0,
@@ -357,14 +357,16 @@ class FlipPage extends React.Component {
 
   render() {
     const { children } = this.props;
-
+    const { page } = this.state;
+    const from = page > 0 ? page - 1 : 0;
+    const to = from + 3;
     return (
       <View
         style={styles.container}
         {...this.panResponder.panHandlers}
         onLayout={this.onLayout}
       >
-        {children.map(this.renderPage)}
+        {children.slice(from, to).map((component, index) => this.renderPage(component, from + index))}
       </View>
     );
   }

--- a/src/styles.js
+++ b/src/styles.js
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
   container: {
     flex: 1,
+    overflow: 'hidden',
   },
   page: {
     position: 'absolute',

--- a/src/styles.js
+++ b/src/styles.js
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
   container: {
     flex: 1,
-    overflow: 'hidden',
   },
   page: {
     position: 'absolute',


### PR DESCRIPTION
Hi, it's me again :).

I had some issues with the rendering of several items (60+) in the flip-page. It was slow and laggy. With hundreds of items the app just freezed so I updated the render method for rendering only needed (previous, current, next) children instead of all of them. 
In the test app it helped a lot with the performance. 
```
<View style={{ overflow: 'hidden', height: 200 }}>
    <FlipPage orientation="horizontal">
        {
            new Array(666).fill().map((_, index) => (
                <FlipPagePage key={index}>
                    <View style={{ flexDirection: 'row' }}>
                        <Text style={{ color: '#000', flex: 1 }}>LEFT {index}</Text>
                        <Text style={{ color: '#000', flex: 1 }}>RIGHT {index}</Text>
                    </View>
                </FlipPagePage>
            ))
        }
    </FlipPage>
</View>
```

Thank you for the cool module. 

P. S. Just ignore the overflow:hidden commit. It didn't work. It's because of weird rendering pages above the horizontal "swipe". 

